### PR TITLE
defeating object mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,269 @@
 ![](https://github.com/lorenzoferre/javascript-deobfuscator/actions/workflows/ci.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-# javascript deobfuscator
+# Javascript deobfuscator
+# Usage
+First of all you need to install the package:
+```
+npm i @lorenzoferre/deobfuscator
+```
+Then you import the deobfuscation function into your module which takes the obfuscated code as input:
+```javascript
+import deobfuscate from "@lorenzoferre/deobfuscator";
+const code = `` // Insert the code here
+const deobfuscatedCode = deobfuscate(code)
+console.log(deobfuscatedCode.code)
+```
+Or if you want to use a file:
+```javascript
+import deobfuscate from "@lorenzoferre/deobfuscator";
+import fs from "fs";
 
-Deobfuscate javascript code using abstract syntaxt trees \
-The documentation will be ready shortly \
-Feel free to contribute :)
+const path = ""; // Insert the file path
+const code = fs.readFileSync(path, "utf-8");
+const deobfuscatedCode = deobfuscate(code)
+console.log(deobfuscatedCode.code)
+```
+ 
+# Techniques
+### Remove dead code
+It removes parts of the code that are useless.
+These could be variables or functions, an example:
+```javascript
+function a() {} 
+function b() {a();} 
+function c() {a(); b();} 
+console.log("a");
+```
+Result:
+```javascript
+console.log("a");
+```
+ _a_ function is called by _b_ and _c_, _b_ is called by _c_, but _c_ is not called by anyone, so none of these functions are called.
+### Rename variables in the same scope
+It aims to make the code more readble, an example:
+```javascript
+let x = 0; 
+{ 
+    let x = 30;
+    x += 1; 
+}
+x += 1;
+```
+Result:
+```javascript
+let x = 0; 
+{ 
+    let _x = 30;
+    _x += 1; 
+}
+x += 1;
+```
+Only the variabile _x_ changes within the block statement to avoid misunderstanding with the global variable _x_.
+### Constant propagation
+It propagates constant values across all occurrences, an example:
+```javascript
+var a = 1;
+console.log(a)
+```
+Result:
+```javascript
+console.log(1)
+```
+Once the value is propagated, this technique deletes the variable declaration.
+A counterexample:
+```javascript
+var a = 1;
+a += 1;
+console.log(a)
+```
+Every time there is at least one update or assignment expression the variable is no longer constant, so we can't propagate the value.
+### Evaluation
+It evaluates all expressions that contain only constant values, an example:
+```javascript
+console.log(1 + 1);
+console.log("hello".replace("h","H"));
+console.log(parseInt("1"));
+```
+Result:
+```javascript
+console.log(2);
+console.log("Hello";
+console.log(1);
+```
+### Replace single constant violations
+It replaces all assignments, which are single constant violations, with variable declarations.
+As I said before every time thare is at least one assignment the variable is no longer constant, so with this technique it is possible to make a constant variable declaration.
+An example:
+```javascript
+var a;
+a = 1;
+```
+Result:
+```javascript
+
+var a = 1;
+```
+### Replace outermost iife
+It extracts the body of the outermost iife and replace all with this one,
+an example:
+```javascript
+(function () { console.log(5);})();
+```
+Or
+```javascript
+(() => { console.log(5);})();
+```
+Result in both cases is the same:
+```javascript
+console.log(5);
+```
+But if there is a return into the iife, it remeins unchanged.
+### Defeating array mapping
+It replaces member expressions that access the elements of an array with its value.
+The value inside the array must be a node of type literal though.
+An example:
+```javascript
+var _0x3baf=["Hello Venus","log","Hello Earth","Hello Mars"];
+console[_0x3baf[1]](_0x3baf[0]);
+console[_0x3baf[1]](_0x3baf[2]);
+console[_0x3baf[1]](_0x3baf[3]);
+```
+Result:
+```javascript
+console.log("Hello Venus");console.log("Hello Earth");console.log("Hello Mars");
+```
+### Transform brackets notation into dots notation
+It transforms the brackets notation into dots notation, an example:
+```javascript
+console.log("hello"["replace"]("h","H"));
+```
+Result:
+```javascript
+console.log("hello".replace("h","H"));
+```
+This transformation does not occur when accessing the attributes of an object or array element, an example:
+```javascript
+var obj = {"a":1, "b":2};
+console.log(obj["a"]);
+```
+In this case it is not transformed into _obj.a_
+### Replace null values with undefined
+It replaces null values with undefined to be evaluated later, an example:
+```javascript
+console.log(+([[[[[[]], , ,]]]] != 0));
+```
+Result:
+```javascript
+console.log(+([[[[[[]],undefined,undefined,]]]] != 0));
+```
+The evaluation of the last piece of code:
+```javascript
+console.log(1);
+```
+### Evaluate conditional statements
+It checks wheater the test value of if or ternary operators is always true or false.
+In the first case it replaces the entire if statement with the true branch, in the second with the false branch.
+An example:
+```javascript
+if (1 == 1) { console.log("1 == 1"); }
+```
+Result:
+```javascript
+console.log("1 == 1");
+```
+Another example:
+```javascript
+if (1 != 1) { console.log("1 == 1"); } else {}
+```
+Result:
+```javascript
+
+```
+### Control flow unflattening
+It reconstructs the normal flow of the code.
+In special cases it must embed the assignments in the variable declarations (as in the case of the single constant violation) and then move them before loops.
+In this way variables can be propagated if they are declared with a literal type node.
+##### Move declarations before loops
+If you declare variables inside loops they are not constant.
+In fact this technique moves declarations before loops, an example:
+```javascript
+var a = 1;
+var b,c;
+do {
+switch(a) {
+case 1: { a = 3; } break;
+case 2: { c = a * b; } break;
+case 3: { b = 10; a = 2; } break;
+}
+}while(c != 20);
+console.log(c);
+```
+Result:
+```javascript
+var c = a * b;
+var b = 10;
+do {
+  switch (a) {
+    case 1:
+      {
+        a = 3;
+      }
+      break;
+    case 2:
+      {}
+      break;
+    case 3:
+      {
+        a = 2;
+      }
+      break;
+  }
+} while (c != 20);
+console.log(c);
+```
+#### Main technique
+This technique verifies that the switch test variable identifier refers to a variable declared with a literal type node.
+So by finding this value you can understand which case is accessed first.
+Once the first one has been understood, the identifier of the test variable is searched to obtain the next value and consequently access to the next switch case and so on.
+### Remove empty statements
+It removes empty elements, an example:
+```javascript
+;;;console.log(1);;;
+```
+Result:
+```javascript
+console.log(1);
+```
+# To do
+I would like to get the results returned by functions:
+```javascript
+function add(a, b) {
+    return a + b;
+}
+console.log(add(1,1));
+```
+Exprected result:
+```javascript
+console.log(2);
+```
+Evaluate dynamic expressions:
+```javascript
+var a = 1;
+a += 1;
+console.log(a);
+```
+Expected result:
+```javascript
+console.log(2);
+```
+Evaluate a special case of Jsfuck notation like this:
+```javascript
+console.log(([]["flat"] +[])[1]);
+```
+Expected result:
+```javascript
+console.log("u");
+```
+Feel free to contribute, I would really appreciate it.
+My goal is to build a deobfuscator that is as general as possible, in fact when I learn to use the _vm_ module the part of the code that deals with control flow unflattening will have to be rewritten.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
-  "name": "deobfuscator",
-  "version": "1.0.0",
+  "name": "@lorenzoferre/deobfuscator",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "deobfuscator",
-      "version": "1.0.0",
+      "name": "@lorenzoferre/deobfuscator",
+      "version": "1.0.1",
       "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.23.0"
-      },
       "devDependencies": {
         "@babel/core": "^7.23.0",
         "@babel/parser": "^7.23.0",
@@ -34,6 +31,7 @@
       "version": "7.22.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
       "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.22.13",
         "chalk": "^2.4.2"
@@ -85,6 +83,7 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
       "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -115,6 +114,7 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
       "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -123,6 +123,7 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
       "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
         "@babel/types": "^7.23.0"
@@ -135,6 +136,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
       "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -189,6 +191,7 @@
       "version": "7.22.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -200,6 +203,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
       "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -208,6 +212,7 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -239,6 +244,7 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
       "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -252,6 +258,7 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
       "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -263,6 +270,7 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
       "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/parser": "^7.22.15",
@@ -276,6 +284,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
       "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",
@@ -296,6 +305,7 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
       "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -309,6 +319,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -322,6 +333,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -330,6 +342,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -337,12 +350,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
       "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -352,6 +367,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -392,9 +408,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001547",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
-      "integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==",
+      "version": "1.0.30001549",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001549.tgz",
+      "integrity": "sha512-qRp48dPYSCYaP+KurZLhDYdVE+yEyht/3NlmcJgVQ2VMGt6JL36ndQ/7rgspdZsJuxDPFIo/OzBT2+GmIJ53BA==",
       "dev": true,
       "funding": [
         {
@@ -415,6 +431,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -428,6 +445,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -435,7 +453,8 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -447,6 +466,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -460,9 +480,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.551",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.551.tgz",
-      "integrity": "sha512-/Ng/W/kFv7wdEHYzxdK7Cv0BHEGSkSB3M0Ssl8Ndr1eMiYeas/+Mv4cNaDqamqWx6nd2uQZfPz6g25z25M/sdw==",
+      "version": "1.4.554",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.554.tgz",
+      "integrity": "sha512-Q0umzPJjfBrrj8unkONTgbKQXzXRrH7sVV7D9ea2yBV3Oaogz991yhbpfvo2LMNkJItmruXTEzVpP9cp7vaIiQ==",
       "dev": true
     },
     "node_modules/escalade": {
@@ -478,6 +498,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -495,6 +516,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -503,6 +525,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -510,12 +533,14 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -547,7 +572,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/node-releases": {
       "version": "2.0.13",
@@ -574,6 +600,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -585,6 +612,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@lorenzoferre/deobfuscator",
-  "version": "1.0.0",
+  "version": "1.0.0-beta",
   "description": "Automation of the javascript deobfuscation process using abstract syntaxt trees",
-  "main": "main.js",
+  "main": "src/deobfuscator.js",
   "scripts": {
     "test": "node --test ./test"
   },
@@ -27,8 +27,5 @@
     "@babel/core": "^7.23.0",
     "@babel/parser": "^7.23.0",
     "@babel/types": "^7.22.5"
-  },
-  "dependencies": {
-    "@babel/traverse": "^7.23.0"
   }
 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues ?            | 
| Patch: Bug Fix ?          |
| Major: Breaking Change ?  |
| Minor: New Feature ?      | Yes
| Tests Added + Pass ?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes ?  |
| License                  | MIT

Add a new feature to defeat an object mapping with only node literals , an example:
```js
var code = `
var obj = {"a": 1};
console.log(obj.a)
`
const deobfuscatedCode = deobfuscate(code);
console.log(deobfuscatedCode)
```
The deobfuscated code:
```js
console.log(1);
```
