### PR TITLE
transform function expressions to function declarations

### DIFF
--- a/src/deobfuscator.js
+++ b/src/deobfuscator.js
@@ -2,6 +2,7 @@ import { transform } from "@babel/core";
 import { changed, setChanged } from "./utils/util.js";
 import removeDeadCode from "./techniques/remove-dead-code.js";
 import renameVariableSameScope from "./techniques/rename-variable-same-scope.js";
+import replaceFunctionExpressionWithFunctionDeclaration from "./techniques/replace-function-expression-with-function-declaration.js";
 import constantPropagation from "./techniques/constant-propagation.js";
 import evaluate from "./techniques/evaluate.js";
 import replaceSingleConstantViolation from "./techniques/replace-single-constant-violation.js";
@@ -22,6 +23,7 @@ export default function deobfuscate(code) {
       plugins: [
         removeDeadCode,
         renameVariableSameScope,
+        replaceFunctionExpressionWithFunctionDeclaration,
         constantPropagation,
         evaluate,
         replaceSingleConstantViolation,

--- a/src/techniques/replace-function-expression-with-function-declaration.js
+++ b/src/techniques/replace-function-expression-with-function-declaration.js
@@ -1,0 +1,28 @@
+import { setChanged } from "../utils/util.js";
+
+export default function (babel) {
+  const { types: t } = babel;
+
+  return {
+    name: "replace-function-expression-with-function-declaration",
+    visitor: {
+      VariableDeclaration(path) {
+        const { node } = path;
+        const { declarations } = node;
+        if (declarations.length !== 1) return;
+        const declaration = declarations[0];
+        if (!t.isFunctionExpression(declaration.init)) return;
+        path.replaceWith(
+          t.functionDeclaration(
+            declaration.id,
+            declaration.init.params,
+            declaration.init.body,
+            declaration.init.generator,
+            declaration.init.async
+          )
+        );
+        setChanged(true);
+      },
+    },
+  };
+}

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,9 @@ test("transform function expressions into function declarations", () => {
       `)
     ),
     `function sum(a, b) { return a + b; } console.log(sum(2, 4));`
+  );
+});
+
 test("reconstruct variable declarations", () => {
   assert.strictEqual(
     removeNewLinesAndTabs(

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,21 @@ function removeNewLinesAndTabs(pieceOfCode) {
   return pieceOfCode.split("\n").join(" ").split("  ").join("");
 }
 
+test("transform function expressions into function declarations", () => {
+  assert.strictEqual(
+    removeNewLinesAndTabs(
+      deobfuscate(`
+        var sum = function(a, b) {
+          return a + b;
+        }
+        var a = 2;
+        console.log(sum(a, 2*a));
+      `)
+    ),
+    `function sum(a, b) { return a + b; } console.log(sum(2, 4));`
+  );
+});
+
 test("hex to value", () => {
   assert.strictEqual(deobfuscate(`console.log("\x61\x61\x61")`), `console.log("aaa");`);
 });


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues ?            |
| Patch: Bug Fix ?          |
| Major: Breaking Change ?  |
| Minor: New Feature ?      | Yes
| Tests Added + Pass ?      |
| Documentation PR Link    | 
| Any Dependency Changes ?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Transform function expressions to function declarations as follows:
```javascript
var sum = function (a, b) {
  return a + b;
};
```
The result:
```javascript
function sum(a, b) {
  return a + b;
}
```