### PR TITLE
transform sequence expressions

### DIFF
--- a/src/deobfuscator.js
+++ b/src/deobfuscator.js
@@ -12,6 +12,7 @@ import replaceOutermostIife from "./techniques/statics/replace-outermost-iife.js
 import defeatingArrayMapping from "./techniques/statics/defeating-array-mapping.js";
 import defeatingObjectMapping from "./techniques/statics/defeating-object-mapping.js";
 import transformBracketToDot from "./techniques/statics/transform-bracket-to-dot.js";
+import transformSequenceExpression from "./techniques/statics/transform-sequence-expression.js";
 import replaceNullToUndefined from "./techniques/statics/replace-null-to-undefined.js";
 import evaluateConditionStatement from "./techniques/statics/evaluate-condition-statement.js";
 import controlFlowUnflattening from "./techniques/statics/control-flow-unflattening.js";
@@ -35,6 +36,7 @@ export default function deobfuscate(code, dynamic = false) {
         defeatingArrayMapping,
         defeatingObjectMapping,
         transformBracketToDot,
+        transformSequenceExpression,
         replaceNullToUndefined,
         evaluateConditionStatement,
         controlFlowUnflattening,

--- a/src/techniques/statics/transform-sequence-expression.js
+++ b/src/techniques/statics/transform-sequence-expression.js
@@ -1,0 +1,19 @@
+import { setChanged } from "../../utils/util.js";
+
+export default function (babel) {
+  return {
+    name: "transform-sequence-expression",
+    visitor: {
+      SequenceExpression(path) {
+        const { node } = path;
+        const { expressions } = node;
+        let newExpression = [];
+        for (const expression of expressions) {
+          newExpression.push(expression);
+        }
+        path.replaceWithMultiple(newExpression);
+        setChanged(true);
+      },
+    },
+  };
+}

--- a/test/test-static-techniques.js
+++ b/test/test-static-techniques.js
@@ -42,6 +42,21 @@ test("bracket to dot", () => {
   assert.strictEqual(deobfuscate(`console["log"]("a")`), `console.log("a");`);
 });
 
+test("transform sequence expression", () => {
+  assert.strictEqual(
+    removeNewLinesAndTabs(
+      deobfuscate(
+        `
+        var a = 1;
+        var b = 1;
+        a = 2, b = 2;
+        `
+      )
+    ),
+    `var a = 1; var b = 1; a = 2; b = 2;`
+  );
+});
+
 test("remove empty statement", () => {
   assert.strictEqual(deobfuscate(`;;;console.log("a");;;`), `console.log("a");`);
 });


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues ?            | 
| Patch: Bug Fix ?          |
| Major: Breaking Change ?  |
| Minor: New Feature ?      | Yes
| Tests Added + Pass ?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes ?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Transform sequence expressions, like this:
```javascript
var a = 1;
var b = 1;
a = 2, b = 2;
```
The result:
```javascript
var a = 1;
var b = 1;
a = 2; 
b = 2;
```