### PR TITLE
fix evaluation of arrow functions with literal type nodes

### DIFF
--- a/src/deobfuscator.js
+++ b/src/deobfuscator.js
@@ -2,7 +2,6 @@ import { transform } from "@babel/core";
 import { changed, setChanged } from "./utils/util.js";
 import removeDeadCode from "./techniques/statics/remove-dead-code.js";
 import renameVariableSameScope from "./techniques/statics/rename-variable-same-scope.js";
-import replaceFunctionExpressionWithFunctionDeclaration from "./techniques/statics/replace-function-expression-with-function-declaration.js";
 import reconstructVariableDeclaration from "./techniques/statics/reconstruct-variable-declaration.js";
 import constantPropagation from "./techniques/statics/constant-propagation.js";
 import evaluate from "./techniques/statics/evaluate.js";
@@ -26,7 +25,6 @@ export default function deobfuscate(code, dynamic = false) {
       plugins: [
         removeDeadCode,
         renameVariableSameScope,
-        replaceFunctionExpressionWithFunctionDeclaration,
         reconstructVariableDeclaration,
         constantPropagation,
         evaluate,

--- a/test/test-dynamic-techniques.js
+++ b/test/test-dynamic-techniques.js
@@ -1,4 +1,4 @@
-import { test, describe } from "node:test";
+import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import deobfuscate from "../src/deobfuscator.js";
@@ -19,5 +19,35 @@ test("evaluation of functions with literal node type as inputs", () => {
       )
     ),
     `console.log(4);`
+  );
+});
+
+test("evaluation of arrow functions with literal node type as inputs and implicit return", () => {
+  assert.strictEqual(
+    removeNewLinesAndTabs(
+      deobfuscate(
+        `
+        let sum = (a,b) => a + b;
+        console.log(sum(2,2));
+        `,
+        true
+      )
+    ),
+    `console.log(4);`
+  );
+});
+
+test("evaluation of arrow functions with literal node type as inputs", () => {
+  assert.strictEqual(
+    removeNewLinesAndTabs(
+      deobfuscate(
+        `
+        let sub = (a,b) => {return a - b;};
+        console.log(sub(4,2));
+        `,
+        true
+      )
+    ),
+    `console.log(2);`
   );
 });

--- a/test/test-static-techniques.js
+++ b/test/test-static-techniques.js
@@ -5,24 +5,6 @@ import deobfuscate from "../src/deobfuscator.js";
 
 import { removeNewLinesAndTabs } from "../src/utils/util.js";
 
-test("transform function expressions into function declarations", () => {
-  assert.strictEqual(
-    removeNewLinesAndTabs(
-      deobfuscate(
-        `
-        var sum = function(a, b) {
-          return a + b;
-        }
-        var a = 2;
-        console.log(sum(a, 2*a));
-      `,
-        false
-      )
-    ),
-    `function sum(a, b) { return a + b; } console.log(sum(2, 4));`
-  );
-});
-
 test("reconstruct variable declarations", () => {
   assert.strictEqual(
     removeNewLinesAndTabs(


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues ?            | 
| Patch: Bug Fix ?          |
| Major: Breaking Change ?  |
| Minor: New Feature ?      | Yes
| Tests Added + Pass ?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes ?  |
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Fix evaluation of arrow functions with literal type nodes.
An example:
```js
let sum = (a,b) => a + b;
let mul = (a,b) => {return a * b}
console.log(sum(2,2));
console.log(mul(5,5));
```
The result:
```js
console.log(4);
console.log(25);
```
