### PR TITLE
fix switch with case label 0

### DIFF
--- a/src/techniques/dynamics/control-flow-unflattening.js
+++ b/src/techniques/dynamics/control-flow-unflattening.js
@@ -9,7 +9,7 @@ export default function (babel) {
   function buildSwitchCases(switchStatement) {
     let switchCases = {};
     for (const switchCase of switchStatement.cases) {
-      const key = switchCase.test.value || switchCase.test.name;
+      const key = switchCase.test.value ?? switchCase.test.name;
       switchCases[key] = switchCase.consequent;
     }
     return switchCases;


### PR DESCRIPTION
Truthy check instead of `undefined`/`null` check, which caused an exception for `case 0:`:

```
file:///private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/javascript-deob/src/techniques/dynamics/control-flow-unflattening.js:60
            for (const switchCaseNode of switchCaseNodes) {
                                         ^

TypeError: unknown file: switchCaseNodes is not iterable
    at PluginPass.enter (file:///private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/javascript-deob/src/techniques/dynamics/control-flow-unflattening.js:60:42)
    at newFn (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/visitors.js:172:14)
    at NodePath._call (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/path/context.js:49:20)
    at NodePath.call (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/path/context.js:39:18)
    at NodePath.visit (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/path/context.js:88:31)
    at TraversalContext.visitQueue (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/context.js:90:16)
    at TraversalContext.visitSingle (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/context.js:66:19)
    at TraversalContext.visit (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/context.js:113:19)
    at traverseNode (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/traverse-node.js:22:17)
    at NodePath.visit (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/path/context.js:94:52)
    at TraversalContext.visitQueue (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/context.js:90:16)
    at TraversalContext.visitMultiple (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/context.js:62:17)
    at TraversalContext.visit (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/context.js:111:19)
    at traverseNode (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/traverse-node.js:22:17)
    at NodePath.visit (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/path/context.js:94:52)
    at TraversalContext.visitQueue (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/context.js:90:16)
    at TraversalContext.visitSingle (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/context.js:66:19)
    at TraversalContext.visit (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/context.js:113:19)
    at traverseNode (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/traverse-node.js:22:17)
    at traverse (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/traverse/lib/index.js:53:34)
    at transformFile (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/core/lib/transformation/index.js:80:31)
    at transformFile.next (<anonymous>)
    at run (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/core/lib/transformation/index.js:25:12)
    at run.next (<anonymous>)
    at transform (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/core/lib/transform.js:22:33)
    at transform.next (<anonymous>)
    at evaluateSync (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/gensync/index.js:251:28)
    at sync (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/gensync/index.js:89:14)
    at stopHiding - secret - don't use this - v1 (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/core/lib/errors/rewrite-stack-trace.js:47:12)
    at transform (/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/@babel/core/lib/transform.js:36:80)
    at deobfuscate (file:///private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/node_modules/javascript-deob/src/deobfuscator.js:21:13)
    at file:///private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.nfpgs5x1xR/deobfuscate.mjs:6:26
    at ModuleJob.run (node:internal/modules/esm/module_job:234:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:473:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:122:5) {
  code: 'BABEL_TRANSFORM_ERROR'
}
```

| Q                        | A
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->