### PR TITLE
Fix loop with empty condition

### DIFF
--- a/src/techniques/dynamics/control-flow-unflattening.js
+++ b/src/techniques/dynamics/control-flow-unflattening.js
@@ -78,7 +78,7 @@ export default function (babel) {
                 }
               }
             }
-            let testOuterLoop = vm.runInContext(generate(node.test).code, context);
+            let testOuterLoop = node.test === null || vm.runInContext(generate(node.test).code, context);
             if (!testOuterLoop) doHaveToSearch = false;
             iteration++;
           }


### PR DESCRIPTION
In JavaScript `for`/`while` loop without a condition is equivalent to a condition always evaluating to true

Fix https://github.com/lorenzoferre/deobfuscator/issues/79

| Q                        | A
| ------------------------ | ---
| Fixed Issues ?            | Fixes #79 <!-- remove the (`) quotes and write "Fixes" before the number to link the issues -->
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
